### PR TITLE
@ #94 | upgrade kubespray to v2.12.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,13 +19,13 @@ teracy-dev-k8s:
       git:
         remote:
           origin: https://github.com/kubernetes-sigs/kubespray.git
-        branch: v2.9.0 # v2.10.0 is buggy https://github.com/kubernetes-sigs/kubespray/issues/4695
+        branch: v2.12.1 # v2.10.0 is buggy https://github.com/kubernetes-sigs/kubespray/issues/4695
   ansible:
     verbose: v
     mode: guest # or host to run ansible from the host instead of from the guest
     playbook_path: cluster.yml # relative within the kubespray repo or /cluster.yml is relative to the Vagrantfile when appending / at the beginning as convention
     # you can add any host_vars here with key-value to override inventory
-    version: 2.7.10 # kubespray is buggy on ansible 2.8: https://github.com/kubernetes-sigs/kubespray/issues/3985
+    version: 2.9.5
     host_vars:
       flannel_interface: "eth1"
       kube_network_plugin: flannel
@@ -40,9 +40,6 @@ teracy-dev-k8s:
       kube_service_addresses: 10.96.0.0/16
       kube_pods_subnet: 10.244.0.0/16
       metrics_server_enabled: true
-      # Directory where credentials will be stored
-      # moved out of inventory_dir to avoid host unreachable problem
-      credentials_dir: "/vagrant/workspace/credentials"
     # added @since v0.4.0
     extra_vars:
       ansible_become_pass: "vagrant"


### PR DESCRIPTION
connect #94 
Result test:
```
iorad-dev                     : ok=728  changed=142  unreachable=0    failed=0   

Tuesday 18 February 2020  19:31:24 +0000 (0:00:00.030)       0:13:10.330 ****** 
=============================================================================== 
download : download_container | Download image if required ------------- 62.11s
container-engine/docker : ensure docker packages are installed --------- 45.36s
download : download_file | Download item ------------------------------- 36.15s
kubernetes/master : kubeadm | Initialize first master ------------------ 29.58s
kubernetes/preinstall : Install packages requirements ------------------ 28.91s
download : download_file | Download item ------------------------------- 27.37s
download : download_container | Download image if required ------------- 25.99s
download : download_container | Download image if required ------------- 18.01s
download : download_container | Download image if required ------------- 14.61s
download : download_container | Download image if required ------------- 14.61s
bootstrap-os : Install dbus for the hostname module -------------------- 14.18s
download : download_container | Download image if required ------------- 14.00s
download : download_container | Download image if required ------------- 13.12s
download : download_file | Download item ------------------------------- 12.90s
download : download_container | Download image if required ------------- 11.98s
download : download_container | Download image if required ------------- 11.97s
download : download_container | Download image if required ------------- 10.88s
download : download_container | Download image if required ------------- 10.71s
download : download_container | Download image if required ------------- 10.48s
download : download_file | Download item ------------------------------- 10.28s
```
Please check this PR! Thank you.